### PR TITLE
Add low-bit GEMM function with CPU/MPS/CUDA support

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -4,7 +4,7 @@ from transformers import LlamaConfig, AutoTokenizer
 from transformers.models.llama.modeling_llama import LlamaModel
 from transformers.activations import ACT2FN
 from llama_model import LlamaModel
-from quantization_utils import activation_norm_quant, gemm_lowbit_kernel_mps
+from quantization_utils import activation_norm_quant, gemm_lowbit
 from safetensors.torch import load
 import time
 import psutil
@@ -22,7 +22,7 @@ class BitLinear(nn.Linear):
         w = self.weight  # a 1.58-bit weight tensor with shape [d, k]
         w_scale = self.weight_scale  # a full-precision weight scale tensor with shape [1]
         x_quant, x_scale = activation_norm_quant(x)
-        y = gemm_lowbit_kernel_mps(x_quant, w) / w_scale / x_scale
+        y = gemm_lowbit(x_quant, w) / w_scale / x_scale
         return y
 
 

--- a/llama_model.py
+++ b/llama_model.py
@@ -5,7 +5,7 @@ try:
     from transformers import LlamaConfig, AutoTokenizer
 except Exception:  # pragma: no cover - transformers may be missing
     LlamaConfig = AutoTokenizer = None  # type: ignore[misc]
-from quantization_utils import quantize_tensor, activation_quant, weight_quant, activation_norm_quant, gemm_lowbit_kernel_mps, kv_cache_quant, act_quant_8bit, act_quant_4bit, quantize_tensor_1_58bit
+from quantization_utils import quantize_tensor, activation_quant, weight_quant, activation_norm_quant, gemm_lowbit, kv_cache_quant, act_quant_8bit, act_quant_4bit, quantize_tensor_1_58bit
 try:
     from safetensors.torch import save_file, load_file
 except Exception:  # pragma: no cover - safetensors may be missing

--- a/tests/test_lowbit_kernel.py
+++ b/tests/test_lowbit_kernel.py
@@ -1,0 +1,15 @@
+import unittest
+import torch
+from quantization_utils import gemm_lowbit
+
+class LowBitKernelTest(unittest.TestCase):
+    def test_matches_matmul(self):
+        torch.manual_seed(0)
+        x = torch.randint(-2, 3, (8, 6), dtype=torch.int8)
+        w = torch.randint(-2, 3, (4, 6), dtype=torch.int8)
+        out = gemm_lowbit(x, w)
+        ref = (x.to(torch.float32) @ w.to(torch.float32).t())
+        self.assertTrue(torch.equal(out, ref))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `gemm_lowbit` as custom autograd kernel replacing placeholder
- update inference and model imports to use new helper
- test low-bit matmul against `torch.matmul`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559c62cc6883249177e48a73729363