### PR TITLE
Add energy RL training demo with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,20 @@ python simple_reward_model.py --epochs 100 --lr 0.1
 The demo prints higher scores for correct answers and can be extended to create
 custom reward models for GRPO training.
 
+## Energy RL Demo
+
+The repository also includes a small reinforcement learning environment to
+experiment with energy‑aware scheduling. The `energy_rl_train.py` script trains a
+tabular Q‑learning agent and reports the average reward before and after
+training. Environment parameters can be customised on the command line:
+
+```bash
+python energy_rl_train.py --episodes 100 --max_steps 20 --harvest_rate 3
+```
+
+This prints the initial and final rewards so you can verify the agent learns a
+better policy.
+
 ## Running the Tests
 
 Unit tests cover the data utilities, GRPO trainer, reward models and

--- a/energy_rl.py
+++ b/energy_rl.py
@@ -104,3 +104,17 @@ def train(agent: QLearningAgent, episodes=10, max_steps=50):
             if done:
                 break
     return agent
+
+
+def evaluate(agent: QLearningAgent, episodes: int = 5, max_steps: int = 50) -> float:
+    """Run episodes using the greedy policy and return the average reward."""
+    total = 0.0
+    for _ in range(episodes):
+        state = agent.env.reset()
+        for _ in range(max_steps):
+            action = int(np.argmax(agent.q_table[state]))
+            state, reward, done = agent.env.step(action)
+            total += reward
+            if done:
+                break
+    return total / episodes

--- a/energy_rl_train.py
+++ b/energy_rl_train.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Train the energy RL agent with configurable environment parameters."""
+import argparse
+from energy_rl import EnergyEnv, QLearningAgent, train, evaluate, EnvConfig
+
+
+def get_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train the energy RL agent")
+    parser.add_argument("--max_energy", type=int, default=10)
+    parser.add_argument("--thermal_limit", type=int, default=10)
+    parser.add_argument("--harvest_rate", type=float, default=2.0)
+    parser.add_argument("--idle_cost", type=float, default=0.5)
+    parser.add_argument("--compute_cost", type=float, default=1.5)
+    parser.add_argument("--compute_heat", type=float, default=2.0)
+    parser.add_argument("--heat_dissipation", type=float, default=1.0)
+    parser.add_argument("--cool_cost", type=float, default=0.2)
+    parser.add_argument("--episodes", type=int, default=50,
+                        help="Training episodes")
+    parser.add_argument("--max_steps", type=int, default=50,
+                        help="Steps per episode")
+    parser.add_argument("--alpha", type=float, default=0.1)
+    parser.add_argument("--gamma", type=float, default=0.9)
+    parser.add_argument("--epsilon", type=float, default=0.1)
+    return parser
+
+
+def run(args: argparse.Namespace) -> tuple[float, float]:
+    cfg = EnvConfig(
+        max_energy=args.max_energy,
+        thermal_limit=args.thermal_limit,
+        harvest_rate=args.harvest_rate,
+        idle_cost=args.idle_cost,
+        compute_cost=args.compute_cost,
+        compute_heat=args.compute_heat,
+        heat_dissipation=args.heat_dissipation,
+        cool_cost=args.cool_cost,
+    )
+    env = EnergyEnv(cfg)
+    agent = QLearningAgent(env, alpha=args.alpha,
+                           gamma=args.gamma, epsilon=args.epsilon)
+    print("Evaluating untrained agent...")
+    pre = evaluate(agent, episodes=5, max_steps=args.max_steps)
+    print(f"Average reward before training: {pre:.2f}")
+    train(agent, episodes=args.episodes, max_steps=args.max_steps)
+    post = evaluate(agent, episodes=5, max_steps=args.max_steps)
+    print(f"Average reward after training: {post:.2f}")
+    return pre, post
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = get_arg_parser()
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_energy_train_script.py
+++ b/tests/test_energy_train_script.py
@@ -1,0 +1,17 @@
+import unittest
+from energy_rl_train import get_arg_parser, run
+
+
+class EnergyTrainScriptTest(unittest.TestCase):
+    def test_reward_improves(self):
+        parser = get_arg_parser()
+        args = parser.parse_args([
+            '--episodes', '30',
+            '--max_steps', '10',
+        ])
+        pre, post = run(args)
+        self.assertGreaterEqual(post, pre)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a CLI script `energy_rl_train.py` to train the energy RL agent
- implement `evaluate` helper in `energy_rl.py`
- add unit test ensuring reward increases after training
- document the demo in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685620dcacd48324bb84a53b5a732b60