### PR TITLE
Add paper hyperparameter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ forward KL estimator $\sum_t p_\theta(t) (\log p_\theta(t) - \log p_{\text{ref}}
 averaged over tokens.
 
 ```bash
-python grpo_train.py --dataset qa.jsonl --model_path path/to/model \
-    --output_dir grpo_out --steps 1000 --csv_log metrics.csv
+python grpo_train.py --config scripts/paper_config.json --dataset qa.jsonl \
+    --model_path path/to/model --output_dir grpo_out --csv_log metrics.csv
 ```
 
 ## Hardware and Example Commands

--- a/scripts/paper_config.json
+++ b/scripts/paper_config.json
@@ -1,0 +1,8 @@
+{
+  "batch_size": 32,
+  "group_size": 8,
+  "lr": 5e-7,
+  "max_length": 8196,
+  "beta": 0.001,
+  "steps": 1000
+}


### PR DESCRIPTION
## Summary
- add `scripts/paper_config.json` with GRPO paper hyperparameters
- update README example to use `--config scripts/paper_config.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a24f2d3d083248583f0efcc252182