### PR TITLE
Add RL inference scheduling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,16 +397,29 @@ python reward_train.py --pairs pairs.jsonl --tokenizer path/to/tokenizer
 ## Energy RL Demo
 
 The repository also includes a small reinforcement learning environment to
-experiment with energy‑aware scheduling. The `energy_rl_train.py` script trains a
-tabular Q‑learning agent and reports the average reward before and after
-training. Environment parameters can be customised on the command line:
+experiment with energy‑aware scheduling. This environment is **independent of
+the GRPO training scripts** and serves solely as a demonstration. The
+`energy_rl_train.py` script trains a tabular Q‑learning agent and reports the
+average reward before and after training. Environment parameters can be
+customised on the command line:
 
 ```bash
 python energy_rl_train.py --episodes 100 --max_steps 20 --harvest_rate 3
 ```
 
 This prints the initial and final rewards so you can verify the agent learns a
-better policy.
+better policy. Once trained the agent can also control scheduling during
+inference. The `energy_inference_schedule.py` script trains a short policy and
+lets it decide when tokens are generated:
+
+```bash
+python energy_inference_schedule.py --model_path path/to/model \
+    --prompt "Hello" --tokens 20
+```
+
+Compute actions produce new tokens while idle or cool actions simply update the
+energy state. This shows how reinforcement learning could influence inference
+scheduling.
 
 ## Running the Tests
 

--- a/energy_inference_schedule.py
+++ b/energy_inference_schedule.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Example showing how the energy RL agent can schedule inference.
+
+The agent interacts with ``EnergyEnv`` and controls when tokens are generated.
+A compute action triggers a one token decode step while other actions skip
+generation to simulate idling or cooling. This demonstrates how reinforcement
+learning could manage energy and thermal constraints during model inference.
+"""
+
+import argparse
+from typing import Iterable
+
+import torch
+
+from energy_rl import EnergyEnv, QLearningAgent, train
+from inference import load_quantized_model
+
+
+def get_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run inference with scheduling from the RL agent"
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--tokens", type=int, default=20,
+                        help="Maximum tokens to generate")
+    parser.add_argument("--episodes", type=int, default=30,
+                        help="Training episodes for the agent")
+    return parser
+
+
+def _generate_step(model, tokenizer, input_ids: torch.Tensor) -> torch.Tensor:
+    with torch.no_grad():
+        output = model.generate(input_ids, max_new_tokens=1)
+    return output
+
+
+def run(args: argparse.Namespace) -> str:
+    env = EnergyEnv()
+    agent = QLearningAgent(env)
+    train(agent, episodes=args.episodes, max_steps=args.tokens)
+
+    model, tokenizer = load_quantized_model(args.model_path)
+    input_ids = tokenizer.encode(args.prompt, return_tensors="pt").to(model.lm_head.weight.device)
+
+    state = env.reset()
+    generated = input_ids
+    for _ in range(args.tokens):
+        action = agent.choose_action(state)
+        state, _, done = env.step(action)
+        if done:
+            break
+        if action == 1:  # compute step
+            generated = _generate_step(model, tokenizer, generated)
+    return tokenizer.decode(generated[0], skip_special_tokens=True)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = get_arg_parser()
+    args = parser.parse_args(argv)
+    text = run(args)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_energy_inference_schedule.py
+++ b/tests/test_energy_inference_schedule.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest import mock
+import importlib
+
+TRANS_AVAILABLE = importlib.util.find_spec("transformers") is not None
+
+if TRANS_AVAILABLE:
+    import energy_inference_schedule as eis
+
+
+@unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
+class EnergyInferenceScheduleCLITest(unittest.TestCase):
+    def test_main_calls_run(self):
+        with mock.patch('energy_inference_schedule.run') as run:
+            eis.main(['--model_path', 'm', '--prompt', 'hi'])
+            run.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- show RL-based scheduling with `energy_inference_schedule.py`
- document usage in README
- test CLI entry for the new example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6434e3648324b1d88a5d55940a9f