### PR TITLE
Implement parameter count verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Use `new-model-architecture-creation.py` to generate a blank ternary model.
 Specify the desired parameter count on the command line. The model is written
 to `--output_dir` if provided, otherwise `llama_<params>_ternary_quantized_optimized`.
 Passing `--e` enables an experimental quantisation mode.
+The script now verifies the resulting model size and fails if the parameter
+count differs from the request by more than 1%.
 
 ```bash
 python new-model-architecture-creation.py --params 750M --output_dir llama_750M

--- a/model_utils.py
+++ b/model_utils.py
@@ -1,0 +1,18 @@
+import torch.nn as nn
+
+
+def count_parameters(model: nn.Module) -> int:
+    """Return the total number of parameters in ``model``."""
+    return sum(p.numel() for p in model.parameters())
+
+
+def verify_parameter_count(actual: int, requested: int, tolerance_ratio: float = 0.01) -> None:
+    """Ensure ``actual`` matches ``requested`` within ``tolerance_ratio``."""
+    diff = abs(actual - requested)
+    tolerance = requested * tolerance_ratio
+    print(f"Requested parameters: {requested:,}; actual: {actual:,}")
+    if diff > tolerance:
+        raise ValueError(
+            f"Parameter mismatch exceeds {tolerance_ratio * 100:.2f}% tolerance"
+        )
+

--- a/new-model-architecture-creation.py
+++ b/new-model-architecture-creation.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from transformers import LlamaConfig
 from quantization_utils import activation_quant, quantize_tensor_1_58bit
 from llama_model import LlamaModel, BitLinear
+from model_utils import count_parameters, verify_parameter_count
 from tqdm import tqdm
 import os
 import time
@@ -108,6 +109,8 @@ assert 300_000_000 <= num_params <= 200_000_000_000, "Number of parameters must 
 # Calculate the model dimensions based on the desired number of parameters
 config = calculate_model_dimensions(num_params)
 model = LlamaModel(config, experiment=args.e)
+actual_params = count_parameters(model)
+verify_parameter_count(actual_params, num_params)
 
 # Move the model to the appropriate device
 device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,25 @@
+import unittest
+import torch.nn as nn
+from model_utils import count_parameters, verify_parameter_count
+
+
+class ModelUtilsTest(unittest.TestCase):
+    def test_count_parameters(self):
+        model = nn.Linear(2, 3)
+        self.assertEqual(count_parameters(model), 2 * 3 + 3)
+
+    def test_verify_passes_within_tolerance(self):
+        model = nn.Linear(2, 2)
+        actual = count_parameters(model)
+        # Should not raise for exact value
+        verify_parameter_count(actual, actual)
+        # Should pass with difference below tolerance
+        verify_parameter_count(actual + 1, actual, tolerance_ratio=0.2)
+
+    def test_verify_raises_on_large_difference(self):
+        with self.assertRaises(ValueError):
+            verify_parameter_count(120, 100, tolerance_ratio=0.01)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `model_utils` with helpers to count and verify parameters
- verify the generated model's parameter count in `new-model-architecture-creation.py`
- mention model size verification in README
- add unit tests for the new helper functions

## Testing
- `pytest -q tests/test_model_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b676699688324ba3fc250809e2f19