### PR TITLE
Add multi reward model example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
     --output_dir grpo_model --grad_checkpoint
 ```
 
+### Training with multiple reward models
+
+The repository provides `scripts/grpo_two_rewards.sh` as a minimal example of
+mixing two reward models with custom weights. The same setup can be described in
+JSON and passed via `--config`:
+
+```json
+{
+  "reward_model": ["rm1.ckpt", "rm2.ckpt"],
+  "reward_weights": [0.7, 0.3],
+  "rule_weight": 0.5,
+  "steps": 1000
+}
+```
+
+Save this as `scripts/two_reward_config.json` then run:
+
+```bash
+python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
+    --config scripts/two_reward_config.json --output_dir grpo_model
+```
+
 ## Two-Layer Self-Correction
 
 Passing `--two_layer` enables a second GRPO pass that attempts to refine the first answer.

--- a/scripts/grpo_two_rewards.sh
+++ b/scripts/grpo_two_rewards.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Example GRPO training mixing two reward models.
+# Replace DATA_PATH, MODEL_PATH and reward checkpoint paths as needed.
+DATA_PATH="qa.jsonl"
+MODEL_PATH="llama_750m"
+REWARD_MODEL1="rm1.ckpt"
+REWARD_MODEL2="rm2.ckpt"
+OUTPUT_DIR="grpo_two_rewards"
+python grpo_train.py \
+    --dataset "$DATA_PATH" \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL1" "$REWARD_MODEL2" \
+    --reward_weights 0.7 0.3 \
+    --rule_weight 0.5 \
+    --output_dir "$OUTPUT_DIR"

--- a/scripts/two_reward_config.json
+++ b/scripts/two_reward_config.json
@@ -1,0 +1,6 @@
+{
+  "reward_model": ["rm1.ckpt", "rm2.ckpt"],
+  "reward_weights": [0.7, 0.3],
+  "rule_weight": 0.5,
+  "steps": 1000
+}


### PR DESCRIPTION
## Summary
- add config and bash script demonstrating GRPO training with two reward models
- document multi-reward setup in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6a81741083249649534d39f7bc9e